### PR TITLE
Added hexadecimal to base64 converter Python script

### DIFF
--- a/Hex to Base64 Converter/Hex to Base64 Converter (commented).py
+++ b/Hex to Base64 Converter/Hex to Base64 Converter (commented).py
@@ -1,0 +1,112 @@
+#49276d206b696c6c696e6720796f757220627261696e206c696b65206120706f69736f6e6f7573206d757368726f6f6d
+#SSdtIGtpbGxpbmcgeW91ciBicmFpbiBsaWtlIGEgcG9pc29ub3VzIG11c2hyb29t
+########https://base64.guru/converter/encode/hex;
+hexalph = """!"#$%&'()*+,-./0123456789:'<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~"""
+hexdecalph = '0123456789abcdef'
+finalascii = """ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"""
+fname = 'NEWtestoutput.txt'
+fhand = open(fname, 'w')
+fhand.close()
+fhand = open(fname, 'r+')
+#
+#
+#
+#below starts the function
+def hextodec(hexstring) :
+    #initialize empty list to contain hex pairs
+    hexlist = []
+    #turn the input string into a list
+    hexinput = list(hexstring)
+    #loop through the list of characters and pair them up
+    while len(hexinput) > 0 :
+        #take first two characters, turn them into a string, assign them to a variable
+        hexpair = ''.join(hexinput[:2])
+        fhand.write(f'Parsed hex pair {hexpair}\n')
+        #add the hex pair to the list
+        hexlist.append(hexpair)
+        #remove the first two characters from the original input string list
+        hexinput = hexinput[2:]
+    fhand.write(f'List of parsed hex pairs is {hexlist}\n')
+    declist = []
+    #going through each pair, organizing, and converting to decimal
+    for pair in hexlist :
+        #turn the pair into a list and change to lowercase to match hex character list above
+        hextodecinput = list(pair.lower())
+        fhand.write(f'Lowercase pair list is {hextodecinput}\n')
+        #reverse the list to process from lowest priority to highest
+        hextodecinput.reverse()
+        fhand.write(f'Reversed list is {hextodecinput}\n')
+        total = 0
+        #loop through each character and convert from hexadecimal to decimal
+        for char in hextodecinput :
+            fhand.write(f'{hexdecalph.index(char)} is index of character in hexdecalph list\n')
+            fhand.write(f'{hextodecinput.index(char)} is index of character in input\n')
+            fhand.write(f'{16 ** hextodecinput.index(char)} is 16 to the power of the index of the character in the input\n')
+            fhand.write(f'---Equation will be {hexdecalph.index(char)} * {16 ** hextodecinput.index(char)}\n')
+            #do the actual hexadecimal conversion
+            total += ((hexdecalph.index(char)) * (16 ** hextodecinput.index(char)))
+            fhand.write(f'---Running total is {total}\n')
+        #turn total into a string and append to list
+        total = str(total)
+        fhand.write(f'{total} is decimal conversion\n')
+        declist.append(total)
+    fhand.write(f'{declist} is list of decimal conversions\n')
+    binlist = []
+    #loop through each decimal in the list to convert to final base64 ASCII characters
+    for dec in declist :
+        #convert to integer
+        dec2 = int(dec)
+        #convert to binary, padding with leading zeros if necessary for 8 total characters
+        decbin = f'{dec2:08b}'
+        decbin = list(decbin)
+        decbin = ''.join(decbin)
+        fhand.write(f'{decbin} is binary conversion of decimal\n')
+        binlist.append(decbin)
+    binlist = ''.join(binlist)
+    #to convert to base64, 6bit words are needed. this ensures the list is divisible by 6
+    if not len(binlist) % 6 == 0 :
+        binlist = list(binlist)
+        binlist.append('00')
+        binlist = ''.join(binlist)
+    if not len(binlist) % 6 == 0 :
+        binlist = list(binlist)
+        binlist.append('00')
+        binlist = ''.join(binlist)
+    sixbitlist = []
+    #loop through the list, separating bits out into words of 6
+    while len(binlist) > 0 :
+        binword = binlist[:6]
+        binlist = binlist[6:]
+        binword = ''.join(binword)
+        fhand.write(f'Parsed 6-bit word {binword}\n')
+        sixbitlist.append(binword)
+    finaldeclist = []
+    #loop through each 6-bit word in list, converting to decimal
+    for item in sixbitlist :
+        #convert the word to integer in base2
+        newdec = int(item, 2)
+        newdec = str(newdec)
+        fhand.write(f'{newdec} is decimal conversion of 6-bit word {item}\n')
+        finaldeclist.append(newdec)
+    finalcharlist = []
+    #loop through list of decimal conversions, converting to ASCII using the base64 conversion table
+    for item in finaldeclist :
+        finalchar = int(item)
+        finalchar = finalascii[finalchar]
+        finalchar = str(finalchar)
+        fhand.write(f'{item} is decimal in list to convert using base64 table\n')
+        fhand.write(f'{finalchar} is final character in base64 list using decimal conversion of 6-bit binary word as index\n')
+        finalcharlist.append(finalchar)
+    finalword = ''.join(finalcharlist)
+    finalword = list(finalword)
+    #base64 strings are divisible by 4, so the following three lines ensure that the string is padded with ending '=' if necessary
+    if not len(finalword) % 4 == 0 :
+        finalword.append('=')
+    if not len(finalword) % 4 == 0 :
+        finalword.append('=')
+    if not len(finalword) % 4 == 0 :
+        finalword.append('=')
+    finalword = ''.join(finalword)
+    fhand.write(f'{finalword} is base64 conversion of {hexstring}\n')
+    return finalword
+print(hextodec(input('')))

--- a/Hex to Base64 Converter/Hex to Base64 Converter (condensed).py
+++ b/Hex to Base64 Converter/Hex to Base64 Converter (condensed).py
@@ -1,0 +1,65 @@
+import os,sys
+currentdir=os.path.dirname(os.path.realpath(__file__))
+parentdir=os.path.dirname(currentdir)
+sys.path.append(parentdir)
+hda='0123456789abcdef';b64t="""ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"""
+fn=f'{currentdir}/log.txt';fh=open(fn,'w');fh.close();fh=open(fn,'r+')
+def hextodec(s):
+    l,h=[],list(s)
+    while len(h)>0:
+        hp=''.join(h[:2]);fh.write(f'Parsed hex pair {hp}\n')
+        l.append(hp);h=h[2:]
+    fh.write(f'----List of parsed hex pairs is {l}\n')
+    dl=[]
+    for p in l:
+        dcp=list(p.lower())
+        fh.write(f'\tLowercase pair list is {dcp}\n')
+        dcp.reverse()
+        fh.write(f'\tReversed list is {dcp}\n')
+        t=0
+        for c in dcp:
+            fh.write(f'\t\t{hda.index(c)} is index of character in hda list\n')
+            fh.write(f'\t\t{dcp.index(c)} is index of character in input\n')
+            fh.write(f'\t----{16**dcp.index(c)} is 16 to the power of the index of the character in the input\n')
+            fh.write(f'----Equation will be {hda.index(c)}*{16**dcp.index(c)}\n')
+            t+=((hda.index(c))*(16**dcp.index(c)))
+            fh.write(f'----Running total is {t}\n')
+        t=str(t)
+        fh.write(f'\t\t----{t} is decimal conversion\n')
+        dl.append(t)
+    fh.write(f'____{dl} is list of decimal conversions\n')
+    bl=[]
+    for n in dl:
+        bc=''.join(list(f'{int(n):08b}'))
+        fh.write(f'{bc} is binary conversion of decimal\n')
+        bl.append(bc)
+    bl=''.join(bl)
+    for i in range(2):
+        if not len(bl)%6==0:
+            bl=list(bl)
+            bl.append('00')
+            bl=''.join(bl)
+    sb=[]
+    while len(bl)>0:
+        w,bl=bl[:6],bl[6:]
+        w=''.join(w)
+        fh.write(f'-Parsed 6-bit word {w}\n')
+        sb.append(w)
+    fdl=[]
+    for i in sb:
+        fd=str(int(i,2))
+        fh.write(f'{fd}\tis decimal conversion of 6-bit word {i}\n')
+        fdl.append(fd)
+    fl=[]
+    for i in fdl:
+        c=str(b64t[int(i)])
+        fh.write(f'\t{i} is decimal in list to convert using base64 table\n')
+        fh.write(f'\t----{c} is final character in base64 list using decimal conversion of 6-bit binary word as index\n')
+        fl.append(c)
+    fw=list(''.join(fl))
+    for i in range(3):
+        if not len(fw)%4==0:fw.append('=')
+    fw=''.join(fw)
+    fh.write(f'{fw} is base64 conversion of {s}\n')
+    return fw
+print(hextodec(input('')))

--- a/Hex to Base64 Converter/log.txt
+++ b/Hex to Base64 Converter/log.txt
@@ -1,0 +1,979 @@
+Parsed hex pair 49
+Parsed hex pair 27
+Parsed hex pair 6d
+Parsed hex pair 20
+Parsed hex pair 6b
+Parsed hex pair 69
+Parsed hex pair 6c
+Parsed hex pair 6c
+Parsed hex pair 69
+Parsed hex pair 6e
+Parsed hex pair 67
+Parsed hex pair 20
+Parsed hex pair 79
+Parsed hex pair 6f
+Parsed hex pair 75
+Parsed hex pair 72
+Parsed hex pair 20
+Parsed hex pair 62
+Parsed hex pair 72
+Parsed hex pair 61
+Parsed hex pair 69
+Parsed hex pair 6e
+Parsed hex pair 20
+Parsed hex pair 6c
+Parsed hex pair 69
+Parsed hex pair 6b
+Parsed hex pair 65
+Parsed hex pair 20
+Parsed hex pair 61
+Parsed hex pair 20
+Parsed hex pair 70
+Parsed hex pair 6f
+Parsed hex pair 69
+Parsed hex pair 73
+Parsed hex pair 6f
+Parsed hex pair 6e
+Parsed hex pair 6f
+Parsed hex pair 75
+Parsed hex pair 73
+Parsed hex pair 20
+Parsed hex pair 6d
+Parsed hex pair 75
+Parsed hex pair 73
+Parsed hex pair 68
+Parsed hex pair 72
+Parsed hex pair 6f
+Parsed hex pair 6f
+Parsed hex pair 6d
+----List of parsed hex pairs is ['49', '27', '6d', '20', '6b', '69', '6c', '6c', '69', '6e', '67', '20', '79', '6f', '75', '72', '20', '62', '72', '61', '69', '6e', '20', '6c', '69', '6b', '65', '20', '61', '20', '70', '6f', '69', '73', '6f', '6e', '6f', '75', '73', '20', '6d', '75', '73', '68', '72', '6f', '6f', '6d']
+	Lowercase pair list is ['4', '9']
+	Reversed list is ['9', '4']
+		9 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 9 * 1
+----Running total is 9
+		4 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 4 * 16
+----Running total is 73
+		----73 is decimal conversion
+	Lowercase pair list is ['2', '7']
+	Reversed list is ['7', '2']
+		7 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 7 * 1
+----Running total is 7
+		2 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 2 * 16
+----Running total is 39
+		----39 is decimal conversion
+	Lowercase pair list is ['6', 'd']
+	Reversed list is ['d', '6']
+		13 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 13 * 1
+----Running total is 13
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 109
+		----109 is decimal conversion
+	Lowercase pair list is ['2', '0']
+	Reversed list is ['0', '2']
+		0 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 0 * 1
+----Running total is 0
+		2 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 2 * 16
+----Running total is 32
+		----32 is decimal conversion
+	Lowercase pair list is ['6', 'b']
+	Reversed list is ['b', '6']
+		11 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 11 * 1
+----Running total is 11
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 107
+		----107 is decimal conversion
+	Lowercase pair list is ['6', '9']
+	Reversed list is ['9', '6']
+		9 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 9 * 1
+----Running total is 9
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 105
+		----105 is decimal conversion
+	Lowercase pair list is ['6', 'c']
+	Reversed list is ['c', '6']
+		12 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 12 * 1
+----Running total is 12
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 108
+		----108 is decimal conversion
+	Lowercase pair list is ['6', 'c']
+	Reversed list is ['c', '6']
+		12 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 12 * 1
+----Running total is 12
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 108
+		----108 is decimal conversion
+	Lowercase pair list is ['6', '9']
+	Reversed list is ['9', '6']
+		9 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 9 * 1
+----Running total is 9
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 105
+		----105 is decimal conversion
+	Lowercase pair list is ['6', 'e']
+	Reversed list is ['e', '6']
+		14 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 14 * 1
+----Running total is 14
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 110
+		----110 is decimal conversion
+	Lowercase pair list is ['6', '7']
+	Reversed list is ['7', '6']
+		7 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 7 * 1
+----Running total is 7
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 103
+		----103 is decimal conversion
+	Lowercase pair list is ['2', '0']
+	Reversed list is ['0', '2']
+		0 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 0 * 1
+----Running total is 0
+		2 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 2 * 16
+----Running total is 32
+		----32 is decimal conversion
+	Lowercase pair list is ['7', '9']
+	Reversed list is ['9', '7']
+		9 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 9 * 1
+----Running total is 9
+		7 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 7 * 16
+----Running total is 121
+		----121 is decimal conversion
+	Lowercase pair list is ['6', 'f']
+	Reversed list is ['f', '6']
+		15 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 15 * 1
+----Running total is 15
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 111
+		----111 is decimal conversion
+	Lowercase pair list is ['7', '5']
+	Reversed list is ['5', '7']
+		5 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 5 * 1
+----Running total is 5
+		7 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 7 * 16
+----Running total is 117
+		----117 is decimal conversion
+	Lowercase pair list is ['7', '2']
+	Reversed list is ['2', '7']
+		2 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 2 * 1
+----Running total is 2
+		7 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 7 * 16
+----Running total is 114
+		----114 is decimal conversion
+	Lowercase pair list is ['2', '0']
+	Reversed list is ['0', '2']
+		0 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 0 * 1
+----Running total is 0
+		2 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 2 * 16
+----Running total is 32
+		----32 is decimal conversion
+	Lowercase pair list is ['6', '2']
+	Reversed list is ['2', '6']
+		2 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 2 * 1
+----Running total is 2
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 98
+		----98 is decimal conversion
+	Lowercase pair list is ['7', '2']
+	Reversed list is ['2', '7']
+		2 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 2 * 1
+----Running total is 2
+		7 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 7 * 16
+----Running total is 114
+		----114 is decimal conversion
+	Lowercase pair list is ['6', '1']
+	Reversed list is ['1', '6']
+		1 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 1 * 1
+----Running total is 1
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 97
+		----97 is decimal conversion
+	Lowercase pair list is ['6', '9']
+	Reversed list is ['9', '6']
+		9 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 9 * 1
+----Running total is 9
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 105
+		----105 is decimal conversion
+	Lowercase pair list is ['6', 'e']
+	Reversed list is ['e', '6']
+		14 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 14 * 1
+----Running total is 14
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 110
+		----110 is decimal conversion
+	Lowercase pair list is ['2', '0']
+	Reversed list is ['0', '2']
+		0 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 0 * 1
+----Running total is 0
+		2 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 2 * 16
+----Running total is 32
+		----32 is decimal conversion
+	Lowercase pair list is ['6', 'c']
+	Reversed list is ['c', '6']
+		12 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 12 * 1
+----Running total is 12
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 108
+		----108 is decimal conversion
+	Lowercase pair list is ['6', '9']
+	Reversed list is ['9', '6']
+		9 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 9 * 1
+----Running total is 9
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 105
+		----105 is decimal conversion
+	Lowercase pair list is ['6', 'b']
+	Reversed list is ['b', '6']
+		11 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 11 * 1
+----Running total is 11
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 107
+		----107 is decimal conversion
+	Lowercase pair list is ['6', '5']
+	Reversed list is ['5', '6']
+		5 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 5 * 1
+----Running total is 5
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 101
+		----101 is decimal conversion
+	Lowercase pair list is ['2', '0']
+	Reversed list is ['0', '2']
+		0 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 0 * 1
+----Running total is 0
+		2 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 2 * 16
+----Running total is 32
+		----32 is decimal conversion
+	Lowercase pair list is ['6', '1']
+	Reversed list is ['1', '6']
+		1 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 1 * 1
+----Running total is 1
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 97
+		----97 is decimal conversion
+	Lowercase pair list is ['2', '0']
+	Reversed list is ['0', '2']
+		0 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 0 * 1
+----Running total is 0
+		2 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 2 * 16
+----Running total is 32
+		----32 is decimal conversion
+	Lowercase pair list is ['7', '0']
+	Reversed list is ['0', '7']
+		0 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 0 * 1
+----Running total is 0
+		7 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 7 * 16
+----Running total is 112
+		----112 is decimal conversion
+	Lowercase pair list is ['6', 'f']
+	Reversed list is ['f', '6']
+		15 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 15 * 1
+----Running total is 15
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 111
+		----111 is decimal conversion
+	Lowercase pair list is ['6', '9']
+	Reversed list is ['9', '6']
+		9 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 9 * 1
+----Running total is 9
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 105
+		----105 is decimal conversion
+	Lowercase pair list is ['7', '3']
+	Reversed list is ['3', '7']
+		3 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 3 * 1
+----Running total is 3
+		7 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 7 * 16
+----Running total is 115
+		----115 is decimal conversion
+	Lowercase pair list is ['6', 'f']
+	Reversed list is ['f', '6']
+		15 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 15 * 1
+----Running total is 15
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 111
+		----111 is decimal conversion
+	Lowercase pair list is ['6', 'e']
+	Reversed list is ['e', '6']
+		14 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 14 * 1
+----Running total is 14
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 110
+		----110 is decimal conversion
+	Lowercase pair list is ['6', 'f']
+	Reversed list is ['f', '6']
+		15 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 15 * 1
+----Running total is 15
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 111
+		----111 is decimal conversion
+	Lowercase pair list is ['7', '5']
+	Reversed list is ['5', '7']
+		5 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 5 * 1
+----Running total is 5
+		7 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 7 * 16
+----Running total is 117
+		----117 is decimal conversion
+	Lowercase pair list is ['7', '3']
+	Reversed list is ['3', '7']
+		3 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 3 * 1
+----Running total is 3
+		7 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 7 * 16
+----Running total is 115
+		----115 is decimal conversion
+	Lowercase pair list is ['2', '0']
+	Reversed list is ['0', '2']
+		0 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 0 * 1
+----Running total is 0
+		2 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 2 * 16
+----Running total is 32
+		----32 is decimal conversion
+	Lowercase pair list is ['6', 'd']
+	Reversed list is ['d', '6']
+		13 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 13 * 1
+----Running total is 13
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 109
+		----109 is decimal conversion
+	Lowercase pair list is ['7', '5']
+	Reversed list is ['5', '7']
+		5 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 5 * 1
+----Running total is 5
+		7 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 7 * 16
+----Running total is 117
+		----117 is decimal conversion
+	Lowercase pair list is ['7', '3']
+	Reversed list is ['3', '7']
+		3 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 3 * 1
+----Running total is 3
+		7 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 7 * 16
+----Running total is 115
+		----115 is decimal conversion
+	Lowercase pair list is ['6', '8']
+	Reversed list is ['8', '6']
+		8 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 8 * 1
+----Running total is 8
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 104
+		----104 is decimal conversion
+	Lowercase pair list is ['7', '2']
+	Reversed list is ['2', '7']
+		2 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 2 * 1
+----Running total is 2
+		7 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 7 * 16
+----Running total is 114
+		----114 is decimal conversion
+	Lowercase pair list is ['6', 'f']
+	Reversed list is ['f', '6']
+		15 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 15 * 1
+----Running total is 15
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 111
+		----111 is decimal conversion
+	Lowercase pair list is ['6', 'f']
+	Reversed list is ['f', '6']
+		15 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 15 * 1
+----Running total is 15
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 111
+		----111 is decimal conversion
+	Lowercase pair list is ['6', 'd']
+	Reversed list is ['d', '6']
+		13 is index of character in hda list
+		0 is index of character in input
+	----1 is 16 to the power of the index of the character in the input
+----Equation will be 13 * 1
+----Running total is 13
+		6 is index of character in hda list
+		1 is index of character in input
+	----16 is 16 to the power of the index of the character in the input
+----Equation will be 6 * 16
+----Running total is 109
+		----109 is decimal conversion
+____['73', '39', '109', '32', '107', '105', '108', '108', '105', '110', '103', '32', '121', '111', '117', '114', '32', '98', '114', '97', '105', '110', '32', '108', '105', '107', '101', '32', '97', '32', '112', '111', '105', '115', '111', '110', '111', '117', '115', '32', '109', '117', '115', '104', '114', '111', '111', '109'] is list of decimal conversions
+01001001 is binary conversion of decimal
+00100111 is binary conversion of decimal
+01101101 is binary conversion of decimal
+00100000 is binary conversion of decimal
+01101011 is binary conversion of decimal
+01101001 is binary conversion of decimal
+01101100 is binary conversion of decimal
+01101100 is binary conversion of decimal
+01101001 is binary conversion of decimal
+01101110 is binary conversion of decimal
+01100111 is binary conversion of decimal
+00100000 is binary conversion of decimal
+01111001 is binary conversion of decimal
+01101111 is binary conversion of decimal
+01110101 is binary conversion of decimal
+01110010 is binary conversion of decimal
+00100000 is binary conversion of decimal
+01100010 is binary conversion of decimal
+01110010 is binary conversion of decimal
+01100001 is binary conversion of decimal
+01101001 is binary conversion of decimal
+01101110 is binary conversion of decimal
+00100000 is binary conversion of decimal
+01101100 is binary conversion of decimal
+01101001 is binary conversion of decimal
+01101011 is binary conversion of decimal
+01100101 is binary conversion of decimal
+00100000 is binary conversion of decimal
+01100001 is binary conversion of decimal
+00100000 is binary conversion of decimal
+01110000 is binary conversion of decimal
+01101111 is binary conversion of decimal
+01101001 is binary conversion of decimal
+01110011 is binary conversion of decimal
+01101111 is binary conversion of decimal
+01101110 is binary conversion of decimal
+01101111 is binary conversion of decimal
+01110101 is binary conversion of decimal
+01110011 is binary conversion of decimal
+00100000 is binary conversion of decimal
+01101101 is binary conversion of decimal
+01110101 is binary conversion of decimal
+01110011 is binary conversion of decimal
+01101000 is binary conversion of decimal
+01110010 is binary conversion of decimal
+01101111 is binary conversion of decimal
+01101111 is binary conversion of decimal
+01101101 is binary conversion of decimal
+-Parsed 6-bit word 010010
+-Parsed 6-bit word 010010
+-Parsed 6-bit word 011101
+-Parsed 6-bit word 101101
+-Parsed 6-bit word 001000
+-Parsed 6-bit word 000110
+-Parsed 6-bit word 101101
+-Parsed 6-bit word 101001
+-Parsed 6-bit word 011011
+-Parsed 6-bit word 000110
+-Parsed 6-bit word 110001
+-Parsed 6-bit word 101001
+-Parsed 6-bit word 011011
+-Parsed 6-bit word 100110
+-Parsed 6-bit word 011100
+-Parsed 6-bit word 100000
+-Parsed 6-bit word 011110
+-Parsed 6-bit word 010110
+-Parsed 6-bit word 111101
+-Parsed 6-bit word 110101
+-Parsed 6-bit word 011100
+-Parsed 6-bit word 100010
+-Parsed 6-bit word 000001
+-Parsed 6-bit word 100010
+-Parsed 6-bit word 011100
+-Parsed 6-bit word 100110
+-Parsed 6-bit word 000101
+-Parsed 6-bit word 101001
+-Parsed 6-bit word 011011
+-Parsed 6-bit word 100010
+-Parsed 6-bit word 000001
+-Parsed 6-bit word 101100
+-Parsed 6-bit word 011010
+-Parsed 6-bit word 010110
+-Parsed 6-bit word 101101
+-Parsed 6-bit word 100101
+-Parsed 6-bit word 001000
+-Parsed 6-bit word 000110
+-Parsed 6-bit word 000100
+-Parsed 6-bit word 100000
+-Parsed 6-bit word 011100
+-Parsed 6-bit word 000110
+-Parsed 6-bit word 111101
+-Parsed 6-bit word 101001
+-Parsed 6-bit word 011100
+-Parsed 6-bit word 110110
+-Parsed 6-bit word 111101
+-Parsed 6-bit word 101110
+-Parsed 6-bit word 011011
+-Parsed 6-bit word 110111
+-Parsed 6-bit word 010101
+-Parsed 6-bit word 110011
+-Parsed 6-bit word 001000
+-Parsed 6-bit word 000110
+-Parsed 6-bit word 110101
+-Parsed 6-bit word 110101
+-Parsed 6-bit word 011100
+-Parsed 6-bit word 110110
+-Parsed 6-bit word 100001
+-Parsed 6-bit word 110010
+-Parsed 6-bit word 011011
+-Parsed 6-bit word 110110
+-Parsed 6-bit word 111101
+-Parsed 6-bit word 101101
+18	is decimal conversion of 6-bit word 010010
+18	is decimal conversion of 6-bit word 010010
+29	is decimal conversion of 6-bit word 011101
+45	is decimal conversion of 6-bit word 101101
+8	is decimal conversion of 6-bit word 001000
+6	is decimal conversion of 6-bit word 000110
+45	is decimal conversion of 6-bit word 101101
+41	is decimal conversion of 6-bit word 101001
+27	is decimal conversion of 6-bit word 011011
+6	is decimal conversion of 6-bit word 000110
+49	is decimal conversion of 6-bit word 110001
+41	is decimal conversion of 6-bit word 101001
+27	is decimal conversion of 6-bit word 011011
+38	is decimal conversion of 6-bit word 100110
+28	is decimal conversion of 6-bit word 011100
+32	is decimal conversion of 6-bit word 100000
+30	is decimal conversion of 6-bit word 011110
+22	is decimal conversion of 6-bit word 010110
+61	is decimal conversion of 6-bit word 111101
+53	is decimal conversion of 6-bit word 110101
+28	is decimal conversion of 6-bit word 011100
+34	is decimal conversion of 6-bit word 100010
+1	is decimal conversion of 6-bit word 000001
+34	is decimal conversion of 6-bit word 100010
+28	is decimal conversion of 6-bit word 011100
+38	is decimal conversion of 6-bit word 100110
+5	is decimal conversion of 6-bit word 000101
+41	is decimal conversion of 6-bit word 101001
+27	is decimal conversion of 6-bit word 011011
+34	is decimal conversion of 6-bit word 100010
+1	is decimal conversion of 6-bit word 000001
+44	is decimal conversion of 6-bit word 101100
+26	is decimal conversion of 6-bit word 011010
+22	is decimal conversion of 6-bit word 010110
+45	is decimal conversion of 6-bit word 101101
+37	is decimal conversion of 6-bit word 100101
+8	is decimal conversion of 6-bit word 001000
+6	is decimal conversion of 6-bit word 000110
+4	is decimal conversion of 6-bit word 000100
+32	is decimal conversion of 6-bit word 100000
+28	is decimal conversion of 6-bit word 011100
+6	is decimal conversion of 6-bit word 000110
+61	is decimal conversion of 6-bit word 111101
+41	is decimal conversion of 6-bit word 101001
+28	is decimal conversion of 6-bit word 011100
+54	is decimal conversion of 6-bit word 110110
+61	is decimal conversion of 6-bit word 111101
+46	is decimal conversion of 6-bit word 101110
+27	is decimal conversion of 6-bit word 011011
+55	is decimal conversion of 6-bit word 110111
+21	is decimal conversion of 6-bit word 010101
+51	is decimal conversion of 6-bit word 110011
+8	is decimal conversion of 6-bit word 001000
+6	is decimal conversion of 6-bit word 000110
+53	is decimal conversion of 6-bit word 110101
+53	is decimal conversion of 6-bit word 110101
+28	is decimal conversion of 6-bit word 011100
+54	is decimal conversion of 6-bit word 110110
+33	is decimal conversion of 6-bit word 100001
+50	is decimal conversion of 6-bit word 110010
+27	is decimal conversion of 6-bit word 011011
+54	is decimal conversion of 6-bit word 110110
+61	is decimal conversion of 6-bit word 111101
+45	is decimal conversion of 6-bit word 101101
+	18 is decimal in list to convert using base64 table
+	----S is final character in base64 list using decimal conversion of 6-bit binary word as index
+	18 is decimal in list to convert using base64 table
+	----S is final character in base64 list using decimal conversion of 6-bit binary word as index
+	29 is decimal in list to convert using base64 table
+	----d is final character in base64 list using decimal conversion of 6-bit binary word as index
+	45 is decimal in list to convert using base64 table
+	----t is final character in base64 list using decimal conversion of 6-bit binary word as index
+	8 is decimal in list to convert using base64 table
+	----I is final character in base64 list using decimal conversion of 6-bit binary word as index
+	6 is decimal in list to convert using base64 table
+	----G is final character in base64 list using decimal conversion of 6-bit binary word as index
+	45 is decimal in list to convert using base64 table
+	----t is final character in base64 list using decimal conversion of 6-bit binary word as index
+	41 is decimal in list to convert using base64 table
+	----p is final character in base64 list using decimal conversion of 6-bit binary word as index
+	27 is decimal in list to convert using base64 table
+	----b is final character in base64 list using decimal conversion of 6-bit binary word as index
+	6 is decimal in list to convert using base64 table
+	----G is final character in base64 list using decimal conversion of 6-bit binary word as index
+	49 is decimal in list to convert using base64 table
+	----x is final character in base64 list using decimal conversion of 6-bit binary word as index
+	41 is decimal in list to convert using base64 table
+	----p is final character in base64 list using decimal conversion of 6-bit binary word as index
+	27 is decimal in list to convert using base64 table
+	----b is final character in base64 list using decimal conversion of 6-bit binary word as index
+	38 is decimal in list to convert using base64 table
+	----m is final character in base64 list using decimal conversion of 6-bit binary word as index
+	28 is decimal in list to convert using base64 table
+	----c is final character in base64 list using decimal conversion of 6-bit binary word as index
+	32 is decimal in list to convert using base64 table
+	----g is final character in base64 list using decimal conversion of 6-bit binary word as index
+	30 is decimal in list to convert using base64 table
+	----e is final character in base64 list using decimal conversion of 6-bit binary word as index
+	22 is decimal in list to convert using base64 table
+	----W is final character in base64 list using decimal conversion of 6-bit binary word as index
+	61 is decimal in list to convert using base64 table
+	----9 is final character in base64 list using decimal conversion of 6-bit binary word as index
+	53 is decimal in list to convert using base64 table
+	----1 is final character in base64 list using decimal conversion of 6-bit binary word as index
+	28 is decimal in list to convert using base64 table
+	----c is final character in base64 list using decimal conversion of 6-bit binary word as index
+	34 is decimal in list to convert using base64 table
+	----i is final character in base64 list using decimal conversion of 6-bit binary word as index
+	1 is decimal in list to convert using base64 table
+	----B is final character in base64 list using decimal conversion of 6-bit binary word as index
+	34 is decimal in list to convert using base64 table
+	----i is final character in base64 list using decimal conversion of 6-bit binary word as index
+	28 is decimal in list to convert using base64 table
+	----c is final character in base64 list using decimal conversion of 6-bit binary word as index
+	38 is decimal in list to convert using base64 table
+	----m is final character in base64 list using decimal conversion of 6-bit binary word as index
+	5 is decimal in list to convert using base64 table
+	----F is final character in base64 list using decimal conversion of 6-bit binary word as index
+	41 is decimal in list to convert using base64 table
+	----p is final character in base64 list using decimal conversion of 6-bit binary word as index
+	27 is decimal in list to convert using base64 table
+	----b is final character in base64 list using decimal conversion of 6-bit binary word as index
+	34 is decimal in list to convert using base64 table
+	----i is final character in base64 list using decimal conversion of 6-bit binary word as index
+	1 is decimal in list to convert using base64 table
+	----B is final character in base64 list using decimal conversion of 6-bit binary word as index
+	44 is decimal in list to convert using base64 table
+	----s is final character in base64 list using decimal conversion of 6-bit binary word as index
+	26 is decimal in list to convert using base64 table
+	----a is final character in base64 list using decimal conversion of 6-bit binary word as index
+	22 is decimal in list to convert using base64 table
+	----W is final character in base64 list using decimal conversion of 6-bit binary word as index
+	45 is decimal in list to convert using base64 table
+	----t is final character in base64 list using decimal conversion of 6-bit binary word as index
+	37 is decimal in list to convert using base64 table
+	----l is final character in base64 list using decimal conversion of 6-bit binary word as index
+	8 is decimal in list to convert using base64 table
+	----I is final character in base64 list using decimal conversion of 6-bit binary word as index
+	6 is decimal in list to convert using base64 table
+	----G is final character in base64 list using decimal conversion of 6-bit binary word as index
+	4 is decimal in list to convert using base64 table
+	----E is final character in base64 list using decimal conversion of 6-bit binary word as index
+	32 is decimal in list to convert using base64 table
+	----g is final character in base64 list using decimal conversion of 6-bit binary word as index
+	28 is decimal in list to convert using base64 table
+	----c is final character in base64 list using decimal conversion of 6-bit binary word as index
+	6 is decimal in list to convert using base64 table
+	----G is final character in base64 list using decimal conversion of 6-bit binary word as index
+	61 is decimal in list to convert using base64 table
+	----9 is final character in base64 list using decimal conversion of 6-bit binary word as index
+	41 is decimal in list to convert using base64 table
+	----p is final character in base64 list using decimal conversion of 6-bit binary word as index
+	28 is decimal in list to convert using base64 table
+	----c is final character in base64 list using decimal conversion of 6-bit binary word as index
+	54 is decimal in list to convert using base64 table
+	----2 is final character in base64 list using decimal conversion of 6-bit binary word as index
+	61 is decimal in list to convert using base64 table
+	----9 is final character in base64 list using decimal conversion of 6-bit binary word as index
+	46 is decimal in list to convert using base64 table
+	----u is final character in base64 list using decimal conversion of 6-bit binary word as index
+	27 is decimal in list to convert using base64 table
+	----b is final character in base64 list using decimal conversion of 6-bit binary word as index
+	55 is decimal in list to convert using base64 table
+	----3 is final character in base64 list using decimal conversion of 6-bit binary word as index
+	21 is decimal in list to convert using base64 table
+	----V is final character in base64 list using decimal conversion of 6-bit binary word as index
+	51 is decimal in list to convert using base64 table
+	----z is final character in base64 list using decimal conversion of 6-bit binary word as index
+	8 is decimal in list to convert using base64 table
+	----I is final character in base64 list using decimal conversion of 6-bit binary word as index
+	6 is decimal in list to convert using base64 table
+	----G is final character in base64 list using decimal conversion of 6-bit binary word as index
+	53 is decimal in list to convert using base64 table
+	----1 is final character in base64 list using decimal conversion of 6-bit binary word as index
+	53 is decimal in list to convert using base64 table
+	----1 is final character in base64 list using decimal conversion of 6-bit binary word as index
+	28 is decimal in list to convert using base64 table
+	----c is final character in base64 list using decimal conversion of 6-bit binary word as index
+	54 is decimal in list to convert using base64 table
+	----2 is final character in base64 list using decimal conversion of 6-bit binary word as index
+	33 is decimal in list to convert using base64 table
+	----h is final character in base64 list using decimal conversion of 6-bit binary word as index
+	50 is decimal in list to convert using base64 table
+	----y is final character in base64 list using decimal conversion of 6-bit binary word as index
+	27 is decimal in list to convert using base64 table
+	----b is final character in base64 list using decimal conversion of 6-bit binary word as index
+	54 is decimal in list to convert using base64 table
+	----2 is final character in base64 list using decimal conversion of 6-bit binary word as index
+	61 is decimal in list to convert using base64 table
+	----9 is final character in base64 list using decimal conversion of 6-bit binary word as index
+	45 is decimal in list to convert using base64 table
+	----t is final character in base64 list using decimal conversion of 6-bit binary word as index
+SSdtIGtpbGxpbmcgeW91ciBicmFpbiBsaWtlIGEgcG9pc29ub3VzIG11c2hyb29t is base64 conversion of 49276d206b696c6c696e6720796f757220627261696e206c696b65206120706f69736f6e6f7573206d757368726f6f6d


### PR DESCRIPTION
This is a converter I had originally written for a Codewars kata. It takes as input a hexadecimal string, and provides as output the base64 conversion of the same string. There are two scripts in this; one is a more verbose script with comments explaining how the program works, and the other is condensed with shorter variable names and no excess whitespace. I also included an example log file. The hexadecimal string in the comment on line 1 of the Commented .py file is converted to the base64 string in the comment on line 2. This can be verified with the website shown in the comment on line 3.